### PR TITLE
Add CP850 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ go get -u github.com/mushroomsir/iconv
 - ISO-8859-1
 - EUC-JP
 - Shift_JIS
+- CP850
 - More coming soon
 
 # Usage

--- a/converter.go
+++ b/converter.go
@@ -26,7 +26,8 @@ var (
 	ISO88591   = "ISO-8859-1"
 	EUCJP      = "EUC-JP"
 	ShiftJIS   = "Shift_JIS"
-	charsets   = []string{GBK, GB18030, Big5, ISO88591, EUCJP, ShiftJIS, HZGB2312}
+	CP850      = "CP850"
+	charsets   = []string{GBK, GB18030, Big5, ISO88591, EUCJP, ShiftJIS, HZGB2312, CP850}
 	charsetMap = map[string]transform.Transformer{}
 )
 
@@ -60,6 +61,9 @@ func init() {
 		case HZGB2312:
 			charsetMap[HZGB2312+UTF8] = simplifiedchinese.HZGB2312.NewDecoder()
 			charsetMap[UTF8+HZGB2312] = simplifiedchinese.HZGB2312.NewEncoder()
+		case CP850:
+			charsetMap[CP850+UTF8] = charmap.CodePage850.NewDecoder()
+			charsetMap[UTF8+CP850] = charmap.CodePage850.NewEncoder()
 		}
 	}
 }

--- a/iconv_test.go
+++ b/iconv_test.go
@@ -59,6 +59,8 @@ func TestConvertBytes(t *testing.T) {
 		{"\xba\x7e\xa6\x72", Big5, "漢字", UTF8},
 		{"\xa4\xb3\xa4\xf3\xa4\xcb\xa4\xc1\xa4\xcf\xa1\xa2Python\xa5\xd7\xa5\xed\xa5\xb0\xa5\xe9\xa5\xdf\xa5\xf3\xa5\xb0", EUCJP, "こんにちは、Pythonプログラミング", UTF8},
 		{"\xba\x7e\xa6\x72", Big5, "\xb4\xc1\xbb\xfa", EUCJP},
+		{"é", UTF8, "\x82", CP850},
+		{"\x82", CP850, "é", UTF8},
 	}
 	for _, val := range testCase {
 


### PR DESCRIPTION
Hello @mushroomsir! Thank you for providing this wonderful library!

I saw a need to add CP850 encoding and decoding, for usage with https://github.com/hennedo/escpos/pull/12, as ESCPOS spec-compatible printers (used by receipt printers, but also label printers and certain other devices) require it.